### PR TITLE
Support all headers instead of only a few

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,11 +52,14 @@ function generate_blind_xss_alert(body) {
 function generate_callback_alert(headers, data, url) {
   var alert = "*XSSless: Out-of-Band Callback Alert*\n"
   alert += `• *IP Address:* \`${data["Remote IP"]}\`\n`
-  alert += `• *User-Agent:* \`${headers["user-agent"]}\`\n`
   alert += `• *Request URI:* \`${url}\`\n`
-  if (headers["referer"] !== undefined) {
-    alert += `• *Referer:* \`${headers["referer"]}\`\n`
-  }
+  
+  // Add all the headers
+  for (var key in headers) {
+    if (headers.hasOwnProperty(key)) {       
+      alert += `• *${key}:* \`${headers[key]}\`\n`
+    }
+}
   return(alert)
 }
 


### PR DESCRIPTION
As discussed via PM. I think that we need to support ALL headers.

Here is how it looks:
![xless-all-headers](https://user-images.githubusercontent.com/9288082/99495319-21d11980-297b-11eb-8afb-ad9b7e628dde.png)
